### PR TITLE
Expand website pages and navigation

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact &amp; Community | We Build</title>
+  <title>Contact We Build – Get in Touch</title>
+  <meta name="description" content="Reach out with questions or partnership proposals. We’re here to help you build." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,21 +15,28 @@
     <a href="earn.html">Earn &amp; Contribute</a>
     <a href="governance.html">Governance</a>
     <a href="starter-kits.html">Starter Kits</a>
+    <a href="events.html">Events</a>
+    <a href="team.html">Team</a>
+    <a href="faq.html">FAQ</a>
+    <a href="news.html">News</a>
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Contact &amp; Community</h1>
-  <h2>Join the Discord / Forum</h2>
-  <p><a href="https://discord.example.com">Join our Discord</a> to ask questions and meet others.</p>
+  <h1>Get in Touch</h1>
+  <p>We’d love to hear from you. Reach out with project ideas, partnership opportunities, or general questions.</p>
 
-  <h2>Contact the Core Team</h2>
-  <p>Email us at <a href="mailto:team@example.com">team@example.com</a> for support or collaboration.</p>
+  <h2>Contact Form</h2>
+  <form>
+    <label>Name<br><input type="text"></label><br>
+    <label>Email<br><input type="email"></label><br>
+    <label>Message<br><textarea rows="4"></textarea></label><br>
+    <button type="submit">Send</button>
+  </form>
 
-  <h2>Local Nodes Directory (Coming Soon)</h2>
-  <p>Stay tuned for future listings of local groups and partner organizations.</p>
+  <p>Or email us at <a href="mailto:team@example.com">team@example.com</a>.</p>
 
   <footer>
-    <p>Content is open-source under CC.</p>
+    <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>
   </footer>
 </body>
 </html>

--- a/earn.html
+++ b/earn.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Earn &amp; Contribute | We Build</title>
+  <title>Earn SEED &amp; Contribute – Join We Build</title>
+  <meta name="description" content="See how you can earn SEED tokens by helping develop and share open-source starter kits. Start contributing today." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,24 +15,27 @@
     <a href="earn.html">Earn &amp; Contribute</a>
     <a href="governance.html">Governance</a>
     <a href="starter-kits.html">Starter Kits</a>
+    <a href="events.html">Events</a>
+    <a href="team.html">Team</a>
+    <a href="faq.html">FAQ</a>
+    <a href="news.html">News</a>
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Earn &amp; Contribute</h1>
-  <h2>How to Earn SEED</h2>
-  <p>Get rewarded for community gardening, code contributions, moderating discussions, building tools, or spreading the word.</p>
+  <h1>Start Earning by Building Together</h1>
+  <p>You contribute knowledge, tools, or labor—We Build rewards you. SEED tokens recognize and incentivize positive action in the community.</p>
 
-  <h2>Volunteer Opportunities</h2>
-  <p>We need help across all skill levels—from simple tasks to specialized roles.</p>
+  <h2>Getting Started</h2>
+  <ol>
+    <li>Set up a wallet.</li>
+    <li>Complete tasks from our project list.</li>
+    <li>Earn SEED as you participate.</li>
+  </ol>
 
-  <h2>Hosting Gardens or Skill Circles</h2>
-  <p>Start local gardens or educational meetups and connect them to the DAO.</p>
-
-  <h2>Contribution Dashboard</h2>
-  <p>Track your hours and earned rewards (coming soon).</p>
+  <p>Have questions? Visit the <a href="faq.html">FAQ</a> or <a href="https://discord.example.com">join the Discord</a>.</p>
 
   <footer>
-    <p>Content is open-source under CC.</p>
+    <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>
   </footer>
 </body>
 </html>

--- a/events.html
+++ b/events.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About We Build – Our Mission &amp; Story</title>
-  <meta name="description" content="Discover how We Build empowers communities with open-source tools. Learn about our team and vision." />
+  <title>We Build Events – Workshops &amp; Meetups</title>
+  <meta name="description" content="Find upcoming events and workshops to connect with the We Build community. Register today." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -22,17 +22,13 @@
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Our Mission</h1>
-  <p>Born from a desire to create localized solutions, We Build unites makers, farmers, and innovators to design open-source starter kits that empower communities.</p>
+  <h1>Events</h1>
+  <p>Join our next build weekend or tune into a live workshop. Events bring the community together to share and create.</p>
 
-  <h2>Why We Build</h2>
-  <p>We envision post-capitalist collaboration where practical tools enable everyone to share, grow, and thrive.</p>
-
-  <h2>Community Impact</h2>
-  <p>From gardens to governance, our projects demonstrate the power of collective action.</p>
-
-  <h2>How We Operate</h2>
-  <p>Decentralized decision making keeps us transparent and inclusive. <a href="team.html">Meet the Team</a>.</p>
+  <ul>
+    <li>Meetup – April 15</li>
+    <li>Online Workshop – May 2</li>
+  </ul>
 
   <footer>
     <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>

--- a/faq.html
+++ b/faq.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About We Build – Our Mission &amp; Story</title>
-  <meta name="description" content="Discover how We Build empowers communities with open-source tools. Learn about our team and vision." />
+  <title>We Build FAQ – Answers About SEED &amp; Projects</title>
+  <meta name="description" content="Find common answers on how We Build operates, the SEED token, and how to start contributing." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -22,17 +22,15 @@
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Our Mission</h1>
-  <p>Born from a desire to create localized solutions, We Build unites makers, farmers, and innovators to design open-source starter kits that empower communities.</p>
-
-  <h2>Why We Build</h2>
-  <p>We envision post-capitalist collaboration where practical tools enable everyone to share, grow, and thrive.</p>
-
-  <h2>Community Impact</h2>
-  <p>From gardens to governance, our projects demonstrate the power of collective action.</p>
-
-  <h2>How We Operate</h2>
-  <p>Decentralized decision making keeps us transparent and inclusive. <a href="team.html">Meet the Team</a>.</p>
+  <h1>FAQ</h1>
+  <details>
+    <summary>What is the SEED token?</summary>
+    <p>SEED rewards contributions to community projects.</p>
+  </details>
+  <details>
+    <summary>How do I start a project?</summary>
+    <p>Check our <a href="starter-kits.html">Starter Kits</a> for step-by-step guides.</p>
+  </details>
 
   <footer>
     <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>

--- a/governance.html
+++ b/governance.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Governance | We Build</title>
+  <title>We Build Governance – Token Voting &amp; Proposals</title>
+  <meta name="description" content="Learn how community-driven governance works at We Build. Participate in proposals and shape our future." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,24 +15,24 @@
     <a href="earn.html">Earn &amp; Contribute</a>
     <a href="governance.html">Governance</a>
     <a href="starter-kits.html">Starter Kits</a>
+    <a href="events.html">Events</a>
+    <a href="team.html">Team</a>
+    <a href="faq.html">FAQ</a>
+    <a href="news.html">News</a>
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Governance Portal</h1>
-  <h2>View Proposals</h2>
-  <p>Browse active proposals and join the discussions.</p>
+  <h1>Governance</h1>
+  <p>We Build operates on community-driven governance. Token holders propose and vote on crucial actions, ensuring a collective path forward.</p>
 
-  <h2>Vote Using ROOT Tokens</h2>
-  <p>Cast your vote on community decisions with an easy interface.</p>
+  <h2>Recent Proposals</h2>
+  <p>View proposals and join the discussion in our governance portal.</p>
 
-  <h2>Submit Your Ideas</h2>
-  <p>Use our form to propose new projects or changes. Guidelines help you craft clear proposals.</p>
-
-  <h2>Public Forums for Discussion</h2>
-  <p>Debate and refine proposals in open forums.</p>
+  <h2>Become a Member</h2>
+  <p>Earn SEED to gain voting power, then connect your wallet and participate.</p>
 
   <footer>
-    <p>Content is open-source under CC.</p>
+    <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>
   </footer>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>We Build</title>
+  <title>We Build – Sustainable Open-Source Community</title>
+  <meta name="description" content="Join We Build and earn SEED by creating resilient local projects. Explore starter kits and community governance." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,28 +15,74 @@
     <a href="earn.html">Earn &amp; Contribute</a>
     <a href="governance.html">Governance</a>
     <a href="starter-kits.html">Starter Kits</a>
+    <a href="events.html">Events</a>
+    <a href="team.html">Team</a>
+    <a href="faq.html">FAQ</a>
+    <a href="news.html">News</a>
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>We Build</h1>
-  <h2>Mission Statement</h2>
-  <p>We Build is a grounded DAO committed to cooperation and community empowerment through accessible blockchain tools.</p>
+  <section class="hero">
+    <h1>We Build</h1>
+    <p>Collaborative network shaping resilient, localized communities.</p>
+    <p>
+      <a class="cta" href="earn.html">Become a Builder</a>
+      <a class="cta" href="projects.html">Browse Projects</a>
+    </p>
+  </section>
 
-  <h2>Call to Join as a Builder</h2>
-  <p>Whether you are experienced with crypto or brand new, you are invited to help build a better world.</p>
+  <section>
+    <h2>Our Mission</h2>
+    <p>We Build is a collaborative network shaping resilient, localized communities through open-source starter kits and community-driven governance. Join us to build, earn, and grow together. <a href="about.html">Learn More</a></p>
+  </section>
 
-  <h2>Featured Current Projects</h2>
-  <ul>
-    <li><strong>We Green</strong> – community gardens for local food resilience.</li>
-    <li><strong>We Help</strong> – volunteer networks connecting neighbors.</li>
-    <li><strong>We Choose</strong> – democratic decision-making for our DAO.</li>
-  </ul>
+  <section>
+    <h2>Featured Projects</h2>
+    <div class="project-cards">
+      <div class="project-card">
+        <h3>We Green</h3>
+        <p>Community gardens for local food resilience.</p>
+        <a href="project-we-green.html">Learn More</a>
+      </div>
+      <div class="project-card">
+        <h3>We Help</h3>
+        <p>Volunteer networks connecting neighbors.</p>
+        <a href="project-we-help.html">Learn More</a>
+      </div>
+      <div class="project-card">
+        <h3>We Choose</h3>
+        <p>Democratic decision-making for our DAO.</p>
+        <a href="project-we-choose.html">Learn More</a>
+      </div>
+    </div>
+  </section>
 
-  <h2>How to Get Involved</h2>
-  <p>Jump in by <a href="https://discord.example.com">joining the Discord</a>, signing up for updates, or contributing your skills in coding, gardening, organizing, or resource sharing.</p>
+  <section>
+    <h2>Earn &amp; Contribute</h2>
+    <p>Contribute your skills and start earning SEED tokens today.</p>
+    <a href="earn.html">Start Earning</a>
+  </section>
+
+  <section>
+    <h2>Join the Community</h2>
+    <p><a href="https://discord.example.com">Join our Discord</a> to meet fellow builders and share your ideas.</p>
+  </section>
 
   <footer>
-    <p>Content is open-source under CC. See the <a href="constitution.html">DAO Constitution</a> and <a href="https://github.com/example/token-whitepaper">Token Whitepaper</a>.</p>
+    <p>
+      <a href="index.html">Home</a> ·
+      <a href="about.html">About</a> ·
+      <a href="projects.html">Projects</a> ·
+      <a href="earn.html">Earn &amp; Contribute</a> ·
+      <a href="governance.html">Governance</a> ·
+      <a href="starter-kits.html">Starter Kits</a> ·
+      <a href="events.html">Events</a> ·
+      <a href="team.html">Team</a> ·
+      <a href="faq.html">FAQ</a> ·
+      <a href="news.html">News</a> ·
+      <a href="contact.html">Contact</a>
+    </p>
+    <p><a href="#">Privacy Policy</a> · <a href="#">Terms</a></p>
   </footer>
 </body>
 </html>

--- a/news.html
+++ b/news.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About We Build – Our Mission &amp; Story</title>
-  <meta name="description" content="Discover how We Build empowers communities with open-source tools. Learn about our team and vision." />
+  <title>We Build Blog – Latest Community Updates</title>
+  <meta name="description" content="Read the newest posts about our projects, events, and open-source releases. Stay informed." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -22,17 +22,11 @@
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Our Mission</h1>
-  <p>Born from a desire to create localized solutions, We Build unites makers, farmers, and innovators to design open-source starter kits that empower communities.</p>
-
-  <h2>Why We Build</h2>
-  <p>We envision post-capitalist collaboration where practical tools enable everyone to share, grow, and thrive.</p>
-
-  <h2>Community Impact</h2>
-  <p>From gardens to governance, our projects demonstrate the power of collective action.</p>
-
-  <h2>How We Operate</h2>
-  <p>Decentralized decision making keeps us transparent and inclusive. <a href="team.html">Meet the Team</a>.</p>
+  <h1>Blog</h1>
+  <article>
+    <h2>Welcome to the We Build Blog</h2>
+    <p>Stay up to date on our latest builds, community success stories, and open-source releases.</p>
+  </article>
 
   <footer>
     <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>

--- a/projects.html
+++ b/projects.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Projects | We Build</title>
+  <title>We Build Projects – Open-Source Innovations</title>
+  <meta name="description" content="Browse active and completed projects driving localized solutions. Join, replicate, or submit your own." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,19 +15,34 @@
     <a href="earn.html">Earn &amp; Contribute</a>
     <a href="governance.html">Governance</a>
     <a href="starter-kits.html">Starter Kits</a>
+    <a href="events.html">Events</a>
+    <a href="team.html">Team</a>
+    <a href="faq.html">FAQ</a>
+    <a href="news.html">News</a>
     <a href="contact.html">Contact</a>
   </nav>
 
   <h1>Projects</h1>
-  <p>Explore our live and upcoming initiatives.</p>
-  <ul>
-    <li><a href="project-we-green.html"><strong>We Green</strong></a> – growing community gardens together.</li>
-    <li><a href="project-we-help.html"><strong>We Help</strong></a> – volunteer networks for mutual aid.</li>
-    <li><a href="project-we-choose.html"><strong>We Choose</strong></a> – democratic decision-making for all.</li>
-  </ul>
+  <p>Explore community-driven innovations.</p>
+  <div class="project-cards">
+    <div class="project-card">
+      <h3><a href="project-we-green.html">We Green</a></h3>
+      <p>Growing community gardens together.</p>
+    </div>
+    <div class="project-card">
+      <h3><a href="project-we-help.html">We Help</a></h3>
+      <p>Volunteer networks for mutual aid.</p>
+    </div>
+    <div class="project-card">
+      <h3><a href="project-we-choose.html">We Choose</a></h3>
+      <p>Democratic decision-making for all.</p>
+    </div>
+  </div>
+
+  <p><a href="starter-kits.html">Browse Starter Kits</a> or <a href="earn.html">Become a Contributor</a>.</p>
 
   <footer>
-    <p>Content is open-source under CC.</p>
+    <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>
   </footer>
 </body>
 </html>

--- a/starter-kits.html
+++ b/starter-kits.html
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Starter Kits | We Build</title>
+  <title>Starter Kits – Replicate We Build Projects</title>
+  <meta name="description" content="Access step-by-step guides for replicating sustainable projects. Download and start building in your community." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -14,21 +15,25 @@
     <a href="earn.html">Earn &amp; Contribute</a>
     <a href="governance.html">Governance</a>
     <a href="starter-kits.html">Starter Kits</a>
+    <a href="events.html">Events</a>
+    <a href="team.html">Team</a>
+    <a href="faq.html">FAQ</a>
+    <a href="news.html">News</a>
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Starter Kits / Education</h1>
-  <h2>How to Start Your Own We Green or We Build Project</h2>
-  <p>Follow step-by-step guides and use downloadable templates to launch local initiatives.</p>
+  <h1>Your toolkit for sustainable local solutions</h1>
+  <p>Starter kits empower you to reproduce proven projects. From hydroponic setups to microgrids, get the step-by-step instructions your community needs.</p>
 
-  <h2>Downloads and Tutorials</h2>
-  <p>Find PDFs, guides, and video tutorials covering community organizing and tool-building basics.</p>
-
-  <h2>Crypto 101 for Beginners</h2>
-  <p>Learn how blockchain works, set up a wallet, and participate without prior crypto experience.</p>
+  <h2>Kit Categories</h2>
+  <ul>
+    <li>Garden</li>
+    <li>Energy</li>
+    <li>Housing</li>
+  </ul>
 
   <footer>
-    <p>Content is open-source under CC.</p>
+    <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>
   </footer>
 </body>
 </html>

--- a/style.css
+++ b/style.css
@@ -32,3 +32,34 @@ footer {
   font-size: 0.9rem;
   color: #aaa;
 }
+
+.hero {
+  background-color: #1e1e1e;
+  padding: 2rem;
+  text-align: center;
+  margin-bottom: 2rem;
+}
+.hero .cta {
+  display: inline-block;
+  margin: 0.5rem;
+  padding: 0.5rem 1rem;
+  background-color: #62c4ff;
+  color: #000;
+  border-radius: 4px;
+}
+.project-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+.project-card {
+  background-color: #1e1e1e;
+  padding: 1rem;
+  flex: 1 1 calc(33% - 1rem);
+  box-sizing: border-box;
+}
+@media (max-width: 600px) {
+  .project-card {
+    flex-basis: 100%;
+  }
+}

--- a/team.html
+++ b/team.html
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>About We Build – Our Mission &amp; Story</title>
-  <meta name="description" content="Discover how We Build empowers communities with open-source tools. Learn about our team and vision." />
+  <title>Meet the We Build Team</title>
+  <meta name="description" content="Get to know the minds behind We Build and see how you can join our growing network of builders." />
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
@@ -22,17 +22,19 @@
     <a href="contact.html">Contact</a>
   </nav>
 
-  <h1>Our Mission</h1>
-  <p>Born from a desire to create localized solutions, We Build unites makers, farmers, and innovators to design open-source starter kits that empower communities.</p>
+  <h1>Meet the Builders</h1>
+  <div class="project-cards">
+    <div class="project-card">
+      <h3>Alice</h3>
+      <p>Engineer and urban farmer.</p>
+    </div>
+    <div class="project-card">
+      <h3>Bob</h3>
+      <p>Community organizer and coder.</p>
+    </div>
+  </div>
 
-  <h2>Why We Build</h2>
-  <p>We envision post-capitalist collaboration where practical tools enable everyone to share, grow, and thrive.</p>
-
-  <h2>Community Impact</h2>
-  <p>From gardens to governance, our projects demonstrate the power of collective action.</p>
-
-  <h2>How We Operate</h2>
-  <p>Decentralized decision making keeps us transparent and inclusive. <a href="team.html">Meet the Team</a>.</p>
+  <p><a href="earn.html">Become a Builder</a></p>
 
   <footer>
     <p><a href="index.html">Home</a> · <a href="about.html">About</a> · <a href="projects.html">Projects</a> · <a href="earn.html">Earn &amp; Contribute</a> · <a href="governance.html">Governance</a> · <a href="starter-kits.html">Starter Kits</a> · <a href="events.html">Events</a> · <a href="team.html">Team</a> · <a href="faq.html">FAQ</a> · <a href="news.html">News</a> · <a href="contact.html">Contact</a></p>


### PR DESCRIPTION
## Summary
- rebuild the home page with hero section and calls to action
- update About, Projects, Earn, Governance, Starter Kits and Contact
- add Events, Team, FAQ and News pages
- add a hero and project card styles
- include new footer links on every page

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684cf8e0d358832482433c2f8d0da6b4